### PR TITLE
Add tox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ processed_dataset, contexualized_embeddings = preprocessor.transform(dataset, mo
 
 `processed_dataset` is a dictionary of dictionaries, keyed by partition and training example IDs from the loaded Wiki- or MedHop dataset. For each training example there is a list of dictionaries (one per supporting document) containing
 
-- `'mention'`: the exact text of a candidate found in the supporting document.
-- `'embedding_indices'`: indices into `contexualized_embeddings` which points to the contextual token embeddings for the mention, assigned by `model`.
-- `'corefs'`: a list of coreferring mentions, which themselves are dictionaries with `'mention'` and `'embedding_indices'` keys.
+  - `'mention'`: the exact text of a candidate found in the supporting document.
+  - `'embedding_indices'`: indices into `contexualized_embeddings` which points to the contextual token embeddings for the mention, assigned by `model`.
+  - `'corefs'`: a list of coreferring mentions, which themselves are dictionaries with `'mention'` and `'embedding_indices'` keys.
 
 ### Command line interface (CLI)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ conda activate transformer-gcn-qa
 Next, download the [spaCy](https://spacy.io/) english language model.
 
 ```
-(transformer-gcn-qa) $  python -m spacy download en_core_web_md
+(transformer-gcn-qa) $ python -m spacy download en_core_web_md
 ```
 
 Then follow the instructions [here](https://pytorch.org/get-started/locally/) to install PyTorch for your system. It is highly reccomended that you use a GPU to train the model (or preprocess Wiki- or MedHop) so make sure to install CUDA support. For example, using `conda` and installing for Linux or Windows with CUDA 10.0
@@ -27,10 +27,29 @@ Then follow the instructions [here](https://pytorch.org/get-started/locally/) to
 (transformer-gcn-qa) $ conda install pytorch torchvision cudatoolkit=10.0 -c pytorch
 ```
 
-Finally, install all the other dependencies
+Finally, install this package straight from GitHub
+
+```
+(saber) $ pip install https://github.com/berc-uoft/Transformer-GCN-QA.git
+```
+
+or install by cloning the repository
+
+```
+(transformer-gcn-qa) $ git clone https://github.com/berc-uoft/Transformer-GCN-QA.git
+(transformer-gcn-qa) $ cd Transformer-GCN-QA
+```
+
+and then using either `pip`
 
 ```
 (transformer-gcn-qa) $ pip install -r requirements.txt
+```
+
+ or `setuptools`
+
+```
+(transformer-gcn-qa) $ python setup.py install
 ```
 
 ## Usage
@@ -57,18 +76,18 @@ preprocessor = Preprocessor()
 dataset = load_wikihop('../path/to/dataset')
 model = BERT()
 
-processed_dataset = preprocessor.transform(dataset, model)
+processed_dataset, contexualized_embeddings = preprocessor.transform(dataset, model)
 ```
 
 `processed_dataset` is a dictionary of dictionaries, keyed by partition and training example IDs from the loaded Wiki- or MedHop dataset. For each training example there is a list of dictionaries (one per supporting document) containing
 
-- `'mention'`: the exact text of a candidate found in the supporting document
-- `'embeddings'`: contextual token embeddings for the mention, assigned by `model`
-- `'corefs'`: a list of coreferring mentions, which themselves are dictionaries with `'mention'` and `'embeddings'` keys.
+- `'mention'`: the exact text of a candidate found in the supporting document.
+- `'embedding_indices'`: indices into `contexualized_embeddings` which points to the contextual token embeddings for the mention, assigned by `model`.
+- `'corefs'`: a list of coreferring mentions, which themselves are dictionaries with `'mention'` and `'embedding_indices'` keys.
 
 ### Command line interface (CLI)
 
-Command line interfaces are provided for convience. Pass `--help` to any script to get more usage information, for example
+Command line interfaces are provided for convenience. Pass `--help` to any script to get more usage information, for example
 
 ```
 (transformer-gcn-qa) $ python -m src.cli.preprocess_wikihop --help
@@ -88,11 +107,11 @@ If you have any question about our code or methods, please open an issue.
 
 ### Test suite
 
-The test suite can be found in `src/tests`. With `pytest` installed (`pip install pytest`) the test suite can be run with the following command
+The test suite can be found in `src/tests` and can be run with the following command
 
 ```
 (transformer-gcn-qa) $ cd Transformer-GCN-QA
-(transformer-gcn-qa) $ python -m pytest src/tests --disable-pytest-warnings -v
+(transformer-gcn-qa) $ tox
 ```
 
 ### Installation error from NeuralCoref

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ conda activate transformer-gcn-qa
 (transformer-gcn-qa) $ 
 ```
 
-Next, download the [spaCy](https://spacy.io/) english language model.
+Next, download the [SpaCy](https://spacy.io/) english language model.
 
 ```
 (transformer-gcn-qa) $ python -m spacy download en_core_web_md
@@ -43,13 +43,21 @@ or install by cloning the repository
 and then using either `pip`
 
 ```
-(transformer-gcn-qa) $ pip install -r requirements.txt
+(transformer-gcn-qa) $ pip install -e .
 ```
 
  or `setuptools`
 
 ```
 (transformer-gcn-qa) $ python setup.py install
+```
+
+### Install with development requirements
+
+To run the test suite, you will need to install with
+
+```
+(transformer-gcn-qa) $ pip install -e .[dev]
 ```
 
 ## Usage
@@ -107,7 +115,9 @@ If you have any question about our code or methods, please open an issue.
 
 ### Test suite
 
-The test suite can be found in `src/tests` and can be run with the following command
+The test suite can be found in `src/tests`. To run, first follow the instructions for [installing with development requirements](#install-with-development-requirements)). 
+
+The test suite can then be run with the following command
 
 ```
 (transformer-gcn-qa) $ cd Transformer-GCN-QA

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+spacy==2.1.3
 neuralcoref==4.0
 pytorch-pretrained-bert==0.6.1
-spacy

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+import setuptools
+
+with open("README.MD", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="TransformerGCNQA",
+    version="0.1.0",
+    author="John Giorgi",
+    author_email="johnmgiorgi@gmail.com",
+    license="MIT",
+    description="End-to-end neural question answering achitecture based on transformers and GCNs.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/berc-uoft/Transformer-GCN-QA",
+    python_requires='>=3',
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.7",
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        "Operating System :: OS Independent",
+    ],
+    keywords=[
+        'Natural Language Processing',
+        'Question Answering',
+        'Transformers',
+        'Graph Convolutional Neural Networks'
+        'BERT',
+        'Multi-hop Question Answering',
+    ],
+    install_requires=[
+        "spacy>=2.1.3",
+        "neuralcoref>=4.0",
+        "pytorch-pretrained-bert>=0.6.1",
+    ],
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,11 @@ setuptools.setup(
         "neuralcoref>=4.0",
         "pytorch-pretrained-bert>=0.6.1",
     ],
+    extras_require={
+        "dev": [
+            "pytest",
+            "tox",
+        ]
+    },
     zip_safe=False,
 )

--- a/src/cli/preprocess_wikihop.py
+++ b/src/cli/preprocess_wikihop.py
@@ -39,7 +39,7 @@ def main(input_directory, output_directory):
     ouput_filepath_embeddings = os.path.join(output_directory, 'embeddings.pt')
     torch.save(embeddings, ouput_filepath_embeddings)
 
-    return processed_dataset
+    return processed_dataset, embeddings
 
 
 if __name__ == '__main__':

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -122,10 +122,10 @@ class Preprocessor():
             embedded_doc = torch.index_select(embedded_doc, 0, indices)
 
             # Track the indices of the embeddings for the given tokens
-            embedding_idx_start = 0 if embeddings.shape[0] == 0 else embeddings.shape[0] - 1
+            embedding_idx_start = 0 if embeddings.shape[0] == 0 else embeddings.shape[0]
             embedding_idx_end = embedding_idx_start + embedded_doc.shape[0]
 
-            embedding_indices_ = [i for i in range(embedding_idx_start, embedding_idx_end + 1)]
+            embedding_indices_ = [i for i in range(embedding_idx_start, embedding_idx_end)]
             embedding_indices.extend(embedding_indices_)
 
             # Add embeddings to master list

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -11,7 +11,7 @@ def nlp():
     """Returns a loaded SpaCy model.
     """
     nlp = spacy.load('en_core_web_sm')
-    
+
     return nlp
 
 @pytest.fixture
@@ -26,12 +26,12 @@ def preprocessor(nlp):
 def model():
     """Returns an instance of a BERT object."""
     bert = BERT()
-    
+
     return bert
 
 @pytest.fixture
 def embeddings():
     """Returns an empty torch Tensor"""
     embeddings = torch.tensor([])
-    
+
     return embeddings

--- a/src/tests/test_preprocessor.py
+++ b/src/tests/test_preprocessor.py
@@ -23,7 +23,7 @@ class TestPreprocessor():
         test = preprocessor.nlp('My sister has a dog. She loves him.')
 
         expected_tokens = ['My', 'sister', 'has', 'a', 'dog', '.', 'She', 'loves', 'him', '.']
-        expected_offsets = [(0, 2), (3, 9), (10, 13), (14, 15), (16, 19), (19, 20), (21, 24), 
+        expected_offsets = [(0, 2), (3, 9), (10, 13), (14, 15), (16, 19), (19, 20), (21, 24),
                             (25, 30), (31, 34), (34, 35)]
         expected_corefs = [[(0, 9), (21, 24)], [(14, 19), (31, 34)]]
         expected_embedding_indices = list(range(len(expected_tokens)))

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,32 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = 
+    pyroma
+    py37
+
+[testenv]
+deps =
+    pytest
+    --no-binary neuralcoref
+    -r requirements.txt
+commands =
+    # Tests will run much quicker with the small model
+    python -m spacy download en_core_web_sm
+    python -m pytest src/tests -vv
+
+[testenv:pyroma]
+deps =
+    pygments
+    pyroma
+skip_install = true
+commands = pyroma --min=10 .
+description = Run the pyroma tool to check the project's package friendliness.
+
+# Set max line length for flake8 linter
 [flake8]
 max-line-length = 100
+


### PR DESCRIPTION
This pull request mainly addresses our package structure and unit test pipeline. Everything is now controlled by `tox`. To check our package against best practices and run all unit tests:

```
$ conda activate transformer-gcn-qa
(transformer-gcn-qa) $ cd Transformer-GCN-QA
(transformer-gcn-qa) $ tox
```

A successful run looks like

```
  pyroma: commands succeeded
  py37: commands succeeded
  congratulations :)
```

Note that I could only list one author in the `setup.py` file, not trying to steal all the credit!!

__TODO__

- [x] Add `tox` as a dev dependency to `setup.py`.
- [x] Get TravisCI to trigger on pull request. (I think this will happen on next pull request)