### PR TITLE
Fix install from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then follow the instructions [here](https://pytorch.org/get-started/locally/) to
 Finally, install this package straight from GitHub
 
 ```
-(saber) $ pip install https://github.com/berc-uoft/Transformer-GCN-QA.git
+(transformer-gcn-qa) $ pip install git+https://github.com/berc-uoft/Transformer-GCN-QA.git
 ```
 
 or install by cloning the repository

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.MD", "r") as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Installing from GitHub was broken because `setup.py` pointed to the wrong filepath for `README.md`, and because the `git+` was missing from the git url. The package should now be able to be installed from GitHub with

```
(transformer-gcn-qa) $ pip install git+https://github.com/berc-uoft/Transformer-GCN-QA.git
```

