### PR TITLE
Move SpaCy language model dep to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ $ conda activate transformer-gcn-qa
 (transformer-gcn-qa) $ 
 ```
 
-Next, download the [SpaCy](https://spacy.io/) english language model.
-
-```
-(transformer-gcn-qa) $ pip install spacy
-(transformer-gcn-qa) $ python -m spacy download en_core_web_md
-```
-
 Then follow the instructions [here](https://pytorch.org/get-started/locally/) to install PyTorch for your system. It is highly recommended that you use a GPU to train the model (or preprocess Wiki- or MedHop) so make sure to install CUDA support. For example, using `conda` and installing for Linux or Windows with CUDA 10.0
 
 ```
@@ -31,7 +24,7 @@ Then follow the instructions [here](https://pytorch.org/get-started/locally/) to
 
 The R-GCN implementation is from [pytorch-geometric](https://github.com/rusty1s/pytorch_geometric). Setup involves ensuring various system variables are set followed by `pip` installing a number of packages. Comprehensive installation instructions can be found [here](https://rusty1s.github.io/pytorch_geometric/build/html/notes/installation.html).
 
-Finally, install this package straight from GitHub
+Finally, install this package and its dependencies straight from GitHub
 
 ```
 (transformer-gcn-qa) $ pip install git+https://github.com/berc-uoft/Transformer-GCN-QA.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 spacy==2.1.3
+# SpaCy language model, straight from GitHub
+https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.1.0/en_core_web_md-2.1.0.tar.gz
 neuralcoref==4.0
 pytorch-pretrained-bert==0.6.1
+

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setuptools.setup(
     ],
     install_requires=[
         "spacy>=2.1.3",
+        # SpaCy language model, straight from GitHub
+        "en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-2.1.0/en_core_web_md-2.1.0.tar.gz",
         "neuralcoref>=4.0",
         "pytorch-pretrained-bert>=0.6.1",
     ],


### PR DESCRIPTION
Moves the SpaCy language model dependency to the `setup.py` file. A user no longer has to download this themselves, it is now downloaded and installed when they follow the instructions for installing our package via any of the following methods

```
$ pip install git+https://github.com/berc-uoft/Transformer-GCN-QA.git
```

or

```
$ git clone https://github.com/berc-uoft/Transformer-GCN-QA.git
$ cd Transformer-GCN-QA
```

and then calling one of

```
$ pip install -e .  # OR
$ python setup.py install  # OR
$ pip install -e .[dev]  # OR
```