### PR TITLE
Added masked softmax and CCE loss to forward

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -176,7 +176,7 @@ class TransformerGCNQA(nn.Module):
             self.add_module('RGCN_{}'.format(i), layer)
 
         # Final affine transform
-        self.out = nn.Linear(self.rgcn_size + 768, 1)
+        self.fc_logits = nn.Linear(self.rgcn_size + 768, 1)
 
     def encode_query(self, query):
         """Encodes a query (`query`) using BERT (`self.bert`).
@@ -237,13 +237,24 @@ class TransformerGCNQA(nn.Module):
 
         return query_aware_mention_encoding
 
-    def forward(self, query, encoded_mention, graph):
+    def forward(self, query, encoded_mention, graph, cand_idxs, target=None):
         """Hook for the forward pass of the model.
 
         Args:
             query (str): A string representing the input query from Wiki- or MedHop.
             encoded_mentions (torch.Tensor): A tensor of encoded mentions, of shape
                 (num of encoded mentions x 768).
+            graph (torch.Tensor): A 3xN tensor of graph edges in coordinate format
+                (rows 1 and 2) and edge types (row 3).
+            cand_idxs (dict): A dictionary containing candidate as key and list 
+                of candidate mention indices as values. These indices identify which
+                rows of `encoded_mentions` correspond to mention embeddings of the
+                given candidate.
+            target (torch.Tensor): TODO: is it a tensor or a list? One-hot encoding of
+                the candidate corresponding to the correct answer.
+
+        Returns:
+            TODO.
         """
         encoded_query = self.encode_query(query)
 
@@ -267,6 +278,19 @@ class TransformerGCNQA(nn.Module):
         # Concatenate summed R-GCN output with query
         x_query_cat = torch.cat([x, encoded_query.expand((len(x), -1))], dim=-1)
 
-        out = self.out(x_query_cat)  # N x 1
+        logits = self.fc_logits(x_query_cat)  # N x 1
 
-        return out
+        # Compute the masked softmax based on available candidates
+        masked_softmax = torch.zeros(len(cand_idxs))
+        for i, idxs in enumerate(cand_idxs.values()):
+            logits_masked_max = torch.max(logits[idxs])
+            masked_softmax[i] = torch.exp(logits_masked_max)
+        masked_softmax /= torch.sum(masked_softmax)
+
+        # If target is provided compute loss, otherwise return `masked_softmax`
+        if target is not None:
+            loss_fct = nn.CrossEntropyLoss()
+            loss = loss_fct(masked_softmax.view(-1, len(cand_idxs)), target.view(-1))
+            return loss
+        else:
+            return masked_softmax


### PR DESCRIPTION
The model `forward` function now computes a masked softmax based on passed candidates `cand_idxs` and either outputs this softmax or computes cross-entropy loss if `target` is passed.

I instantiate a tensor of size `len(cand_idxs)` and insert candidate scores one-by-one. In the future we may want to consider vectorizing this but the candidate set cardinalities are so small it's not a significant concern.

Some documentation still needs to be added to `forward`.