### PR TITLE
Switch to pooled output

### DIFF
--- a/src/cli/train.py
+++ b/src/cli/train.py
@@ -17,10 +17,6 @@ from ..utils.train_utils import warn_about_big_graphs
 def main(**kwargs):
     """Runs a training loop for the `TransformerGCNQA` model.
     """
-    model = TransformerGCNQA(**kwargs)
-
-    optimizer = Adam(model.parameters(), lr=kwargs['learning_rate'])
-
     # Load preprocessed Wiki- or MedHop dataset
     processed_dataset, encoded_mentions, graphs, targets = \
         load_preprocessed_wikihop(kwargs['input'])
@@ -29,6 +25,10 @@ def main(**kwargs):
 
     # Warn user with number of empty and big graphs
     warn_about_big_graphs(dataloaders)
+
+    model = TransformerGCNQA(**kwargs)
+
+    optimizer = Adam(model.parameters(), lr=kwargs['learning_rate'])
 
     train(model, optimizer, processed_dataset, dataloaders, **kwargs)
 
@@ -44,7 +44,7 @@ if __name__ == '__main__':
                         help=('Optional, effective batch size achieved with gradient accumulation.'
                               ' Defaults to 32.'))
     parser.add_argument('--dropout_rate', default=0.1, type=float, required=False,
-                        help='Optional, dropout rate. Defaults to 0.2.')
+                        help='Optional, dropout rate. Defaults to 0.1.')
     parser.add_argument('--epochs', default=20, type=int, required=False,
                         help='Optional, number of epochs to train the model for. Defaults to 20.')
     parser.add_argument('--grad_norm', default=0.0, type=float, required=False,
@@ -55,10 +55,10 @@ if __name__ == '__main__':
     # R-GCN
     parser.add_argument('--n_rgcn_layers', default=3, type=int, required=False,
                         help='Optional, number of layers in the R-GCN. Defaults to 3.')
-    parser.add_argument('--n_rels', default=4, type=int, required=False,
+    parser.add_argument('--n_rels', default=3, type=int, required=False,
                         help=('Optional, number of relations in the R-GCN. Set this to 3 if graphs'
                               ' were built with complement=True, otherwise set to 4. Defaults to'
-                              ' 4.'))
+                              ' 3.'))
     parser.add_argument('--rgcn_size', default=128, type=int, required=False,
                         help='Optional, dimensionality of the R-GCN layers. Defaults to 128.')
     parser.add_argument('--n_rgcn_bases', default=2, type=int, required=False,

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,17 +4,6 @@ SPACY_MODEL = 'en_core_web_lg'
 # Greedyness of NeuralCoref. See here: https://github.com/huggingface/neuralcoref#parameters
 NEURALCOREF_GREEDYNESS = 0.40
 
-# Pre-trained BERT models. See here: https://github.com/huggingface/pytorch-pretrained-BERT
-# for more information.
-PRETRAINED_BERT_MODELS = [
-    'bert-base-uncased',
-    'bert-large-uncased',
-    'bert-base-cased',
-    'bert-large-cased',
-    'bert-base-multilingual-uncased',
-    'bert-base-multilingual-cased',
-    'bert-base-chinese',
-]
 # The default pre-trained BERT model to use
 PRETRAINED_BERT_MODEL = 'bert-base-uncased'
 

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -1,11 +1,9 @@
-import pytest
 import torch
 from pytorch_pretrained_bert import BertModel
 from pytorch_pretrained_bert import BertTokenizer
 
 from ..constants import CLS
 from ..constants import SEP
-from ..models import BERT
 
 
 class TestBert(object):
@@ -20,15 +18,8 @@ class TestBert(object):
 
         assert bert.device.type == 'cpu'
 
-    def test_invalid_pretrained_model_value_error(self):
-        """Asserts that `BERT` throws a ValueError when an invalid value for `pretrained_model` is
-        passed."""
-        with pytest.raises(ValueError):
-            BERT(pretrained_model='this should throw a ValueError!')
-
-    def test_predict_on_tokens_simple_full_sequence(self, bert):
-        """Asserts that `BERT.predict_on_tokens` returns the expected value for a simple
-        input when `only_cls=False`.
+    def test_predict_on_tokens_simple(self, bert):
+        """Asserts that `BERT.predict_on_tokens` returns the expected value for a simple input.
         """
         orig_tokens = [
             ["john", "johanson", "'s",  "house"],
@@ -40,30 +31,11 @@ class TestBert(object):
             [1, 2, 3, 4, 5]
         ]
 
-        actual_endcoded_output, actual_orig_to_bert_tok_map = \
-            bert.predict_on_tokens(orig_tokens, only_cls=False)
+        actual_pooled_output, actual_encoded_output, actual_orig_to_bert_tok_map = \
+            bert.predict_on_tokens(orig_tokens)
 
-        assert actual_endcoded_output.shape == (2, 8, 768)
-        assert expected_orig_to_bert_tok_map == actual_orig_to_bert_tok_map
-
-    def test_predict_on_tokens_simple_only_cls(self, bert):
-        """Asserts that `BERT.predict_on_tokens` returns the expected value for a simple
-        input when `only_cls=True`.
-        """
-        orig_tokens = [
-            ["john", "johanson", "'s",  "house"],
-            ["who", "was", "jim", "henson",  "?"]
-        ]
-
-        expected_orig_to_bert_tok_map = [
-            [1, 2, 4, 6],
-            [1, 2, 3, 4, 5]
-        ]
-
-        actual_endcoded_output, actual_orig_to_bert_tok_map = \
-            bert.predict_on_tokens(orig_tokens, only_cls=True)
-
-        assert actual_endcoded_output.shape == (2, 768)
+        assert actual_pooled_output.shape == (2, 768)
+        assert actual_encoded_output.shape == (2, 8, 768)
         assert expected_orig_to_bert_tok_map == actual_orig_to_bert_tok_map
 
     def test_process_tokenized_input_simple(self, bert):
@@ -113,7 +85,7 @@ class TestBert(object):
         actual_bert_tokens, actual_orig_to_bert_tok_map = bert._wordpiece_tokenization(orig_tokens)
 
         assert expected_bert_tokens == actual_bert_tokens
-        assert actual_orig_to_bert_tok_map == expected_orig_to_bert_tok_map
+        assert expected_orig_to_bert_tok_map == actual_orig_to_bert_tok_map
 
 
 class TestTransformerGCNQA(object):


### PR DESCRIPTION
This pull request addresses our use of the CLS token to encode a query. 

We now (correctly) use the `pooled_output` representation from [`pytorch-pretrained-BERT`](https://github.com/huggingface/pytorch-pretrained-BERT)