### PR TITLE
Fix loading of masked data

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -14,9 +14,20 @@ PATH_TO_DUMMY_DATASET = resource_filename(__name__, 'resources/dummy_dataset')
 # Fixtures
 @pytest.fixture
 def dataset():
-    """Returns a loaded dataset, which is structured like Wiki- or MedHop
+    """Returns a loaded dataset, which is structured like Wiki- or MedHop, with `masked==False` in
+    call to `load_wikihop()`.
     """
     dataset = load_wikihop(PATH_TO_DUMMY_DATASET)
+
+    return dataset
+
+
+@pytest.fixture
+def masked_dataset():
+    """Returns a loaded dataset, which is structured like Wiki- or MedHop, where `masked==True` in
+    call to `load_wikihop()`.
+    """
+    dataset = load_wikihop(PATH_TO_DUMMY_DATASET, masked=True)
 
     return dataset
 

--- a/src/tests/resources/dummy_dataset/train.masked.json
+++ b/src/tests/resources/dummy_dataset/train.masked.json
@@ -1,0 +1,31 @@
+[
+    {
+     "id": "WH_train_0",
+     "query": "participant_of juan rossell",
+     "answer": "___MASK3___",
+     "candidates": [
+      "___MASK3___",
+      "___MASK63___",
+      "___MASK83___"
+     ],
+     "supports": [
+        "Juan Miguel Rossell Milanes ( born December 28 , 1969 in Jiguani , Granma ) is a beach volleyball player from Cuba , who won the gold medal in the men ' s beach team competition at the 2003 Pan American Games in Santo Domingo , Dominican Republic , partnering Francisco Alvarez . He represented his native country at the 1996 and the 2004 Summer Olympics ."
+     ]
+    },
+    {
+        "id": "WH_train_1",
+        "query": "languages_spoken_or_written john osteen",
+        "answer": "___MASK46___",
+        "candidates": [
+         "___MASK15___",
+         "___MASK25___",
+         "___MASK46___",
+         "___MASK67___",
+         "___MASK85___"
+        ],
+        "supports": [
+            "Lakewood Church is a nondenominational charismatic Christian megachurch located in Houston , Texas . It is the largest congregation in the United States , averaging about 52 , 000 attendees per week . The 16 , 800 - seat Lakewood Church Central Campus , home to four ___MASK46___ - language services and two Spanish - language services per week , is located at the former Compaq Center . Joel Osteen is the senior pastor of Lakewood Church with his wife , Victoria , who serves as co - pastor . Lakewood Church is a part of the Word of Faith movement .",
+            "Mexico (, modern ___MASK67___ ), officially the United Mexican States , is a federal republic in the southern half of North America . It is bordered to the north by the United States ; to the south and west by the Pacific Ocean ; to the southeast by Guatemala , Belize , and the Caribbean Sea ; and to the east by the Gulf of Mexico . Covering almost two million square kilometers ( over 760 , 000 sq mi ), Mexico is the sixth largest country in the Americas by total area and the 13th largest independent nation in the world . With an estimated population of over 120 million , it is the eleventh most populous country and the most populous ___MASK25___ - speaking country in the world while being the second most populous country in Latin America . Mexico is a federation comprising 31 states and a federal district that is also its capital and most populous city . Other metropolises include Guadalajara , Monterrey , Puebla , Toluca , Tijuana and Le\u00f3n ."
+        ]
+       }
+]

--- a/src/tests/test_dataset_utils.py
+++ b/src/tests/test_dataset_utils.py
@@ -1,0 +1,83 @@
+from ..utils import dataset_utils
+
+
+class TestDatasetUtils(object):
+    """Collects all unit tests for `utils.model_utils`.
+    """
+    def test_load_wikihop(self, dataset):
+        """Asserts that `data_utils.load_wikihop()` returns the expected value when `masked == True`.
+        """
+        expected = {'train': [
+            {
+                "id": "WH_train_0",
+                "query": "participant_of juan rossell",
+                "answer": "1996 summer olympics",
+                "candidates": [
+                    "1996 summer olympics",
+                    "olympic games",
+                    "sport"
+                ],
+                "supports": [
+                    "Juan Miguel Rossell Milanes ( born December 28 , 1969 in Jiguani , Granma ) is a beach volleyball player from Cuba , who won the gold medal in the men 's beach team competition at the 2003 Pan American Games in Santo Domingo , Dominican Republic , partnering Francisco Alvarez . He represented his native country at the 1996 and the 2004 Summer Olympics ."
+                ]
+            },
+            {
+                "id": "WH_train_1",
+                "query": "languages_spoken_or_written john osteen",
+                "answer": "english",
+                "candidates": [
+                    "english",
+                    "greek",
+                    "koine greek",
+                    "nahuatl",
+                    "spanish"
+                ],
+                "supports": [
+                    "Lakewood Church is a nondenominational charismatic Christian megachurch located in Houston, Texas. It is the largest congregation in the United States, averaging about 52,000 attendees per week. The 16,800-seat Lakewood Church Central Campus, home to four English-language services and two Spanish-language services per week, is located at the former Compaq Center. Joel Osteen is the senior pastor of Lakewood Church with his wife, Victoria, who serves as co-pastor. Lakewood Church is a part of the Word of Faith movement.",
+                    "Mexico (, modern Nahuatl ), officially the United Mexican States, is a federal republic in the southern half of North America. It is bordered to the north by the United States; to the south and west by the Pacific Ocean; to the southeast by Guatemala, Belize, and the Caribbean Sea; and to the east by the Gulf of Mexico. Covering almost two million square kilometers (over 760,000\u00a0sq\u00a0mi), Mexico is the sixth largest country in the Americas by total area and the 13th largest independent nation in the world. With an estimated population of over 120 million, it is the eleventh most populous country and the most populous Spanish-speaking country in the world while being the second most populous country in Latin America. Mexico is a federation comprising 31 states and a federal district that is also its capital and most populous city. Other metropolises include Guadalajara, Monterrey, Puebla, Toluca, Tijuana and Le\u00f3n."
+                ]
+            }
+        ]}
+
+        actual = dataset
+
+        assert expected == actual
+
+    def test_load_wikihop_masked(self, masked_dataset):
+        """Asserts that `data_utils.load_wikihop()` returns the expected value when `masked == False`.
+        """
+        expected = {'train.masked': [
+            {
+                "id": "WH_train_0",
+                "query": "participant_of juan rossell",
+                "answer": "___MASK3___",
+                "candidates": [
+                    "___MASK3___",
+                    "___MASK63___",
+                    "___MASK83___"
+                ],
+                "supports": [
+                    "Juan Miguel Rossell Milanes ( born December 28 , 1969 in Jiguani , Granma ) is a beach volleyball player from Cuba , who won the gold medal in the men ' s beach team competition at the 2003 Pan American Games in Santo Domingo , Dominican Republic , partnering Francisco Alvarez . He represented his native country at the 1996 and the 2004 Summer Olympics ."
+                ]
+            },
+            {
+                "id": "WH_train_1",
+                "query": "languages_spoken_or_written john osteen",
+                "answer": "___MASK46___",
+                "candidates": [
+                    "___MASK15___",
+                    "___MASK25___",
+                    "___MASK46___",
+                    "___MASK67___",
+                    "___MASK85___"
+                ],
+                "supports": [
+                    "Lakewood Church is a nondenominational charismatic Christian megachurch located in Houston , Texas . It is the largest congregation in the United States , averaging about 52 , 000 attendees per week . The 16 , 800 - seat Lakewood Church Central Campus , home to four ___MASK46___ - language services and two Spanish - language services per week , is located at the former Compaq Center . Joel Osteen is the senior pastor of Lakewood Church with his wife , Victoria , who serves as co - pastor . Lakewood Church is a part of the Word of Faith movement .",
+                    "Mexico (, modern ___MASK67___ ), officially the United Mexican States , is a federal republic in the southern half of North America . It is bordered to the north by the United States ; to the south and west by the Pacific Ocean ; to the southeast by Guatemala , Belize , and the Caribbean Sea ; and to the east by the Gulf of Mexico . Covering almost two million square kilometers ( over 760 , 000 sq mi ), Mexico is the sixth largest country in the Americas by total area and the 13th largest independent nation in the world . With an estimated population of over 120 million , it is the eleventh most populous country and the most populous ___MASK25___ - speaking country in the world while being the second most populous country in Latin America . Mexico is a federation comprising 31 states and a federal district that is also its capital and most populous city . Other metropolises include Guadalajara , Monterrey , Puebla , Toluca , Tijuana and Le\u00f3n ."
+                ]
+            }
+        ]}
+
+        actual = masked_dataset
+
+        assert expected == actual

--- a/src/utils/dataset_utils.py
+++ b/src/utils/dataset_utils.py
@@ -10,39 +10,37 @@ from ..dataset import Dataset
 # TODO (John): Rewrite this to use googledrivedownloader
 
 
-def load_wikihop(directory, load_masked=False):
+def load_wikihop(directory, masked=False):
     """Loads the Wiki- or MedHop dataset given at `directory`.
 
     Loads the Wiki- or MedHop dataset given at `directory` and returns a dictionary keyed by
-    partition names: 'train', 'dev', 'train.masked', 'dev.masked'. If `load_masked`, the masked
-    partitions of the dataset are loaded, otherwise, 'train.masked' and 'dev.masked' in the returned
-    dictionary are None.
+    partition names. If `masked`, only the masked partitions of the dataset are loaded
+    ('train.masked', 'dev.masked'). Otherwise, only the unmasked partitions are loaded
+    ('train, 'dev').
 
     Args:
         directory (str): Directory path to the Wiki- or MedHop datasets.
-        load_masked (bool): True if the 'train.masked' and 'dev.masked' partitions of the dataset
-            should be loaded. Defaults to False.
+        masked (bool): If True, only the masked partitions of the dataset are loaded
+            ('train.masked', 'dev.masked'). Otherwise, only the unmasked partitions are loaded
+            ('train, 'dev'). Defaults to False.
 
     Returns:
         A dictionary representing the WikiHop or MedHop dataset at `directory`, keyed by partition
-        names: 'train', 'dev', 'train.masked', 'dev.masked'.
+        names.
 
     References:
         - https://qangaroo.cs.ucl.ac.uk/
     """
-    dataset = {'train': None, 'dev': None, 'train.masked': None, 'dev.masked': None}
+    dataset = {}
 
-    for file in os.listdir(directory):
+    partitions = [p for p in glob(os.path.join(directory, '*'))
+                  # Only load masked partitions if `masked` is True
+                  if ('.masked' in p and masked) or ('.masked' not in p and not masked)]
 
-        filename = os.fsdecode(file)
-        partition = filename.split('.json')[0]
-        filepath = os.path.join(directory, filename)
-
-        if filename.endswith('.json'):
-            # Only load masked partitions if `load_masked` is True
-            if 'masked' not in partition or load_masked:
-                with open(filepath, 'r') as f:
-                    dataset[partition] = json.loads(f.read())
+    for partition in partitions:
+        with open(partition, 'r') as f:
+            partition_key = os.path.splitext(os.path.basename(partition))[0]
+            dataset[partition_key] = json.loads(f.read())
 
     return dataset
 


### PR DESCRIPTION
Masked data is now loaded as expected. E.g. `dataset_utils.load_wikihop()` will only load unmasked partitions when `masked==False` (e.g. 'train', 'dev'. Default behaviour) and only masked partitions when `masked==True` (e.g. 'train.masked', 'dev.masked').

__Closes__

Closes #26.