### PR TITLE
Removes erroneous extra softmax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         'Multi-hop Question Answering',
     ],
     install_requires=[
-        "spacy>=2.1.3",
+        "spacy>=2.1.4",
         # SpaCy language model, straight from GitHub
         "en_core_web_lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-2.1.0/en_core_web_lg-2.1.0.tar.gz",
         "neuralcoref>=4.0",
@@ -41,7 +41,7 @@ setuptools.setup(
         "dev": [
             "pytest",
             "tox",
-            "tb-nightly",  # Until 1.14 moves to the release channel"
+            "tb-nightly",  # Until 1.14 moves to the release channel
         ]
     },
     zip_safe=False,

--- a/src/models.py
+++ b/src/models.py
@@ -274,8 +274,7 @@ class TransformerGCNQA(nn.Module):
         logits = self.dropout(logits)
         logits = self.fc_4(logits)
         logits = self.dropout(logits)
-        logits = self.fc_5(logits)
-        logits = self.dropout(logits)  # N x 1, where N = # of candidates
+        logits = self.fc_5(logits)  # N x 1, where N = # of candidates
 
         # Compute the masked softmax based on available candidates
         masked_logits = torch.zeros(len(candidate_indices)).to(self.device)


### PR DESCRIPTION
Because we didn't realize that `CrossEntropyLoss()` itself implements a softmax, we had a second, erroneous softmax at the output of our model. 

This was (likely) smoothing the final output logits resulting in a lesser gradient signal during training.

__TODO__

~~Do we need to add the softmax back in over the logits?~~ No, the output layer is a linear and simply returns a score over all possible candidates. No need to softmax it.