### PR TITLE
Neighbor sampling

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -5,6 +5,7 @@ from pytorch_pretrained_bert import BertTokenizer
 from torch import nn
 
 from torch_geometric.nn import RGCNConv
+from torch_geometric.data import NeighborSampler
 
 from .constants import CLS
 from .constants import PAD


### PR DESCRIPTION
Node-wise batching now works. `torch-cluster` must be updated to most recent version and `torch-geometric` must be installed from GitHub using `pip install git+https://github.com/rusty1s/pytorch_geometric.git`.

Parameters `node_batch_size` and `neighbor_prob` must be kept low in order to avoid OOM errors. The default parameters (`node_batch_size=1` and `neighbor_prob=0.05`) will train without issues when `TRAIN_SIZE_THRESHOLD=10000` in `constants.py`.

Overall, this allows us to filter far fewer graphs, however it does not completely solve OOM issues (i.e. `TRAIN_SIZE_THRESHOLD` cannot be set arbitrarily high). 