### PR TITLE
Filter stop words

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ A Q/A architecture based on transformers and GCNs.
 
 ## Installation
 
-This package requires `python>=3.7` (as we depend on `dict` to retain insertion order) and CUDA 10.0. There are several dependencies not in the `setup.py` that you will need to install before installing this package. 
+This package requires python 3.7+ and CUDA 10.0. There are several dependencies not in the `setup.py` that you will need to install before installing this package. 
 
-First, it is highly recommended that you create a virtual environment. For example, using `conda`
+First, although optional, it is highly recommended that you create a virtual environment. For example, using `conda`
 
-```
+```bash
 $ conda create -n transformer-gcn-qa python=3.7 -y
 $ conda activate transformer-gcn-qa
 # Notice, the prompt has changed to indicate that the enviornment is active
@@ -22,7 +22,7 @@ You will then need to install CUDA 10.0 by following the [installation instructi
 
 With CUDA 10.0 installed, follow the instructions [here](https://pytorch.org/get-started/locally/) to install PyTorch for your system. For example, using `conda` and installing for Linux or Windows with CUDA 10.0
 
-```
+```bash
 (transformer-gcn-qa) $ conda install pytorch torchvision cudatoolkit=10.0 -c pytorch
 ```
 
@@ -30,7 +30,7 @@ The R-GCN implementation is from [pytorch-geometric](https://github.com/rusty1s/
 
 Finally, install this package and its remaining dependencies straight from GitHub
 
-```
+```bash
 (transformer-gcn-qa) $ pip install git+https://github.com/berc-uoft/Transformer-GCN-QA.git
 ```
 
@@ -43,14 +43,20 @@ or install by cloning this repository
 
 and then using either `pip`
 
-```
+```bashen_core_web_lg
 (transformer-gcn-qa) $ pip install -e .
 ```
 
  or `setuptools`
 
-```
+```bash
 (transformer-gcn-qa) $ python setup.py install
+```
+
+Regardless of installation method, you will need to additionally download a [SpaCy](https://spacy.io/) English language model
+
+```bash
+(transformer-gcn-qa) $ python -m spacy download en_core_web_lg
 ```
 
 ### Install with development requirements
@@ -87,51 +93,6 @@ python -m src.cli.train -i path/to/preprocessed/wiki/or/medhop
 
 See below for more detailed usage instructions.
 
-### Classes
-
-The main classes are outlined below. Call `help()` on any method or class to see more usage information, for example
-
-```
->> from src.models import BERT
->> help(BERT)
-```
-
-#### `Preprocessor`
-
-This class provides methods for processing raw text. Most importantly, `Preprocessor.transform()` can be used to transform the Wiki- or MedHop datasets into a format that can then be used to construct a graph for learning with a GCN
-
-```python
-from src.utils.datasets import load_wikihop
-from src.preprocessor import Preprocessor
-from src.models import BERT
-
-preprocessor = Preprocessor()
-dataset = load_wikihop('path/to/wiki/or/medhop')
-model = BERT()
-
-processed_dataset, encoded_mentions, encoded_mentions_split_sizes, targets, targets_split_sizes = preprocessor.transform(dataset, model)
-```
-
-The returned tuple contains 5 dictionaries, keyed by dataset partition, with everything we need for graph construction and training. See `help(Preprocessor.transform)` for more information about each object.
-
-#### `BuildGraph`
-
-This class constructs a heuristic graph for each provided sample. `BuildGraph` is instantiated with the `processed_dataset` output from `Preprocessor` as described above. Calling `BuildGraph.build()` then constructs a graph for each sample in `processed_dataset`.
-
-```python
-from src.preprocessor_graph import BuildGraph
-
-buildGraph = BuildGraph(processed_dataset)
-graphs, idxs = buildGraph.build()
-```
-
-`graphs` is a `3xN` tensor, where `N` is the sum of the number of edges across all graphs in `processed_dataset`. That is, if there are `K` samples in `processed_dataset`, then `N = N_1 + N_2 + ... + N_K` where `N_i` is the number of edges in the graph for sample i. 
-- The first two rows of `graphs` correspond to the i-th and j-th indices of an edge respectively.
-- The third row corresponds to the relation type of the edge (an integer in `[0, 1, 2, 3]`). 
-The edges and corresponding relation types for each graph are concatenated in the second dimension to ensure a single tensor can be saved for all samples.
-
-`idxs` is a dictionary containing sample ids as keys and corresponding graph tensor sizes as values. This allows the correct subtensor corresponding to the given sample from `graphs` to be extracted during training or inference time by using `torch.split()`.
-
 ### Command line interface (CLI)
 
 Command line interfaces are provided for convenience. Pass `--help` to any script to get more usage information, for example
@@ -145,7 +106,7 @@ Command line interfaces are provided for convenience. Pass `--help` to any scrip
 This script will take the Wiki- or MedHop dataset and save to disk everything we need to assemble the graph
 
 ```
-(transformer-gcn-qa) $ python -m src.cli.preprocess_wikihop -i path/to/wiki/or/medhop -o path/to/output
+(transformer-gcn-qa) $ python -m src.cli.preprocess_wikihop -i path/to/wiki/or/medhop -o path/to/preprocessed/wiki/or/medhop
 ```
 
 #### `build_graphs.py`
@@ -153,7 +114,7 @@ This script will take the Wiki- or MedHop dataset and save to disk everything we
 This script will take the pre-processed Wiki- or MedHop dataset and create/save the graph tensors to disk, which are used as inputs to the model.
 
 ```
-(transformer-gcn-qa) $ python -m src.cli.build_graph -i path/to/processed/dataset -o path/to/preprocessed/wiki/or/medhop
+(transformer-gcn-qa) $ python -m src.cli.build_graph -i path/to/preprocessed/wiki/or/medhop
 ```
 
 #### `train.py`
@@ -164,7 +125,7 @@ This script will train a model on a pre-processed Wiki- or MedHop dataset.
 (transformer-gcn-qa) $ python -m src.cli.train -i path/to/preprocessed/wiki/or/medhop
 ```
 
-To monitor performance with TensorBoard, first, make sure you have installed with dev dependencies (`pip install -e .[dev]`). During a training session, call `tensorboard --logdir=runs` and then access port `6006` in your browser.
+To monitor performance with TensorBoard, first, make sure you have [installed with dev dependencies](#install-with-development-requirements). During a training session, call `tensorboard --logdir=runs` and then access port `6006` in your browser.
 
 ## Troubleshooting
 
@@ -186,6 +147,6 @@ The test suite can then be run with the following command
 If you get an error mentioning `spacy.strings.StringStore size changed, may indicate binary incompatibility` you will need to install `neuralcoref` from the distribution's sources
 
 ```
-(transformer-gcn-qa) $ pip uninstall neuralcoref
+(transformer-gcn-qa) $ pip uninstall neuralcoref -y
 (transformer-gcn-qa) $ pip install neuralcoref --no-binary neuralcoref
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ or install by cloning this repository
 
 and then using either `pip`
 
-```bashen_core_web_lg
+```bash
 (transformer-gcn-qa) $ pip install -e .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 spacy==2.1.3
-# SpaCy language model, straight from GitHub
-https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-2.1.0/en_core_web_lg-2.1.0.tar.gz
 neuralcoref==4.0
 pytorch-pretrained-bert==0.6.1
+tensorboard==1.13.1
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
         "spacy>=2.1.4",
         "neuralcoref>=4.0",
         "pytorch-pretrained-bert>=0.6.1",
+        "tensorboard>=1.13.1",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,6 @@ setuptools.setup(
     ],
     install_requires=[
         "spacy>=2.1.4",
-        # SpaCy language model, straight from GitHub
-        "en_core_web_lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-2.1.0/en_core_web_lg-2.1.0.tar.gz",
         "neuralcoref>=4.0",
         "pytorch-pretrained-bert>=0.6.1",
     ],

--- a/src/cli/train.py
+++ b/src/cli/train.py
@@ -4,6 +4,7 @@ Usage:
     `python -m src.cli.train -i ./path/to/preprocessed/dataset`
 """
 import argparse
+from pprint import pprint
 
 from torch.optim import Adam
 
@@ -47,20 +48,20 @@ if __name__ == '__main__':
                         help='Optional, dropout rate. Defaults to 0.1.')
     parser.add_argument('--epochs', default=20, type=int, required=False,
                         help='Optional, number of epochs to train the model for. Defaults to 20.')
-    parser.add_argument('--grad_norm', default=0.0, type=float, required=False,
+    parser.add_argument('--grad_norm', default=1.0, type=float, required=False,
                         help=('Optional, maximum L2 norm to clip all parameter gradients. Set to'
-                              '0 to turn off. Defaults to 0'))
+                              '0 to turn off. Defaults to 1'))
     parser.add_argument('-lr', '--learning_rate', default=1e-4, type=float, required=False,
                         help='Optional, learning rate for the optimizer. Defaults to 1e-4.')
     # R-GCN
     parser.add_argument('--n_rgcn_layers', default=3, type=int, required=False,
                         help='Optional, number of layers in the R-GCN. Defaults to 3.')
     parser.add_argument('--n_rels', default=3, type=int, required=False,
-                        help=('Optional, number of relations in the R-GCN. Set this to 3 if graphs'
-                              ' were built with complement=True, otherwise set to 4. Defaults to'
+                        help=('Optional, number of relations in the R-GCN. Set this to 4 if graphs'
+                              ' were built with complement=True, otherwise set to 3. Defaults to'
                               ' 3.'))
-    parser.add_argument('--rgcn_size', default=128, type=int, required=False,
-                        help='Optional, dimensionality of the R-GCN layers. Defaults to 128.')
+    parser.add_argument('--rgcn_size', default=512, type=int, required=False,
+                        help='Optional, dimensionality of the R-GCN layers. Defaults to 512.')
     parser.add_argument('--n_rgcn_bases', default=2, type=int, required=False,
                         help='TODO (Duncan).')
     # Other
@@ -68,7 +69,11 @@ if __name__ == '__main__':
                         help=('Optional, evaluate model on every evaluation_step number of epochs.'
                               'E.g. if evaluation_step==2, model is evaluated on every 2nd epoch'
                               ' Defaults to 1.'))
+    parser.add_argument('--verbose', action='store_true')
 
-    args = vars(parser.parse_args())
+    kwargs = vars(parser.parse_args())
 
-    main(**args)
+    if kwargs['verbose']:
+        pprint(kwargs)
+
+    main(**kwargs)

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@
 SPACY_MODEL = 'en_core_web_lg'
 
 # Greedyness of NeuralCoref. See here: https://github.com/huggingface/neuralcoref#parameters
-NEURALCOREF_GREEDYNESS = 0.40
+NEURALCOREF_GREEDYNESS = 0.10
 
 # The default pre-trained BERT model to use
 PRETRAINED_BERT_MODEL = 'bert-base-uncased'
@@ -12,4 +12,5 @@ CLS = '[CLS]'  # Special BERT classification token
 SEP = '[SEP]'  # Special BERT sequence seperator token
 
 # Maximum size of a training example, and examples exceeding this size are skipped.
-TRAIN_SIZE_THRESHOLD = 10000
+TRAIN_SIZE_THRESHOLD = 3000
+EVAL_SIZE_THRESHOLD = 3500


### PR DESCRIPTION
## Overview

The pull request primarily adds the ability to filter candidate answers according to a stopword list. Because stopwords are frequent, these mentions are blowing up the size of our graphs.

These are now filtered by default when using `preprocess_wikihop.py`. To retain stopword candidates, use `--retain_stopwords`.

### Additional Changes

- Move SpaCy dependency out of `setup.py` / `requirements.txt`
- Clean up Readme
- Add different graph edge filter sizes for train and eval data (`TRAIN_SIZE_THRESHOLD`, `EVAL_SIZE_THRESHOLD`)
- Increase the default greediness of `NeuralCoref`